### PR TITLE
Changed const char* in a better way

### DIFF
--- a/Number.cpp
+++ b/Number.cpp
@@ -24,12 +24,11 @@ Number::Number(std::string s) : pimpl( new Impl())
     input_string(this->pimpl->value.get_num(), this->pimpl->value.get_den(), s);
     this->pimpl->value.canonicalize();
 }
-Number::Number(const char* s)
+Number::Number(const char* s) : pimpl (new Impl())
 {
     input_string(this->pimpl->value.get_num(), this->pimpl->value.get_den(), std::string(s));
     this->pimpl->value.canonicalize();
 }
-
 Number::Number(const Number& n) : pimpl( new Impl())
 {
     this->pimpl->value = n.pimpl->value;


### PR DESCRIPTION
Basically I was forgetting to construct pimpl for that constructor only. This was creating a case where the function would initialize a null reference and that reference would segfault if it was assigned anything. The fix from sam's fork should work but this is better. Tested the main and I got to the end: "All tests ran for this data structure... oh wow! I'm done. Goodnight moon :)" 